### PR TITLE
enable testing for server code

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,19 +8,23 @@
     "prettier": "prettier --config ./.prettierrc.yml --write ./{tests,gstsrc}/**/*.{js,vue}",
     "dev": "webpack --config webpack.dev.js",
     "prod": "webpack --config webpack.prod.js",
-    "start": "node ./dev-server.js",
+    "start": "node ./tools/dev_server.js",
     "setup:db": "sh ./bin/init-docker.sh",
     "test": "karma start --config karma.conf.js",
     "test:chrome": "karma start --config karma.conf.js --browsers=Chrome",
-    "test_travis":
-      "cross-env BABEL_ENV=test ./node_modules/.bin/karma start --single-run --config karma.conf.js --browsers=Chrome,Firefox",
-    "posttest_travis": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "test_travis": "cross-env BABEL_ENV=test ./node_modules/.bin/karma start --single-run --config karma.conf.js --browsers=Chrome,Firefox",
+    "posttest_travis": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "test:server": "mocha ./tests/server/**/*-test.js --timeout=120000 --watch"
   },
   "lint-staged": {
-    "src/**/*.(js|vue)": ["npm run prettier", "git add"]
+    "src/**/*.(js|vue)": [
+      "npm run prettier",
+      "git add"
+    ]
   },
   "devDependencies": {
     "@vue/test-utils": "^1.0.0-beta.10",
+    "app": "file:./tools",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-istanbul": "^4.1.5",
@@ -81,6 +85,7 @@
     "prettier": "^1.12.0",
     "quill": "^1.3.6",
     "rematrix": "^0.2.2",
+    "supertest": "^3.0.0",
     "uuid": "^3.2.1",
     "vue": "^2.5.13",
     "vue-router": "^3.0.1",

--- a/tests/server/login-test.js
+++ b/tests/server/login-test.js
@@ -1,0 +1,29 @@
+const app = require('../../tools/app.js')
+const request = require('supertest')
+const assert = require('assert')
+
+describe('login', () => {
+
+  it('should attempt to login the test/asdf user', done => {
+    request(app)
+      .post('/resources/cgi-bin/scrollery-cgi.pl')
+      .send({
+        PASSWORD: "asdf",
+        SCROLLVERSION: 1,
+        USER_NAME: "test",
+        transaction: "validateSession"
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .end(function(err, res) {
+        if (err) {
+          return done(err);
+        }
+
+        assert(res.body.SESSION_ID.length > 5);
+        console.log(res);
+        done();
+      });
+  })
+
+})

--- a/tools/app.js
+++ b/tools/app.js
@@ -1,0 +1,21 @@
+const { resolve } = require('path')
+const express = require('express')
+const bodyParser = require('body-parser')
+const perl = require('./perl-cgi-middleware.js')
+
+
+const app = express()
+
+// parse JSON bodies 
+app.use(bodyParser.json({ type: 'application/json' }))
+
+// the index file
+app.get('/', (req, res) => {
+  res.sendFile(resolve(__dirname, '../index.html'))
+})
+
+// handle Perl requests
+app.post(/\.pl/, perl)
+
+// expose the Express app instance
+module.exports = app

--- a/tools/dev_server.js
+++ b/tools/dev_server.js
@@ -1,0 +1,21 @@
+const app = require('./app.js');
+const webpack = require('webpack')
+const middleware = require('webpack-dev-middleware')
+const conf = require('./../webpack.server.js')
+const compiler = webpack(conf)
+
+app.use(require('webpack-hot-middleware')(compiler))
+const serveWebpack = middleware(compiler, {
+  publicPath: '/dist/',
+})
+app.get(/.*/, (req, res, next) => {
+  if (/\/vendors/.test(req.url) || /\/resources/.test(req.url) || /\/node_modules/.test(req.url)) {
+    res.sendFile(resolve.apply(null, [__dirname, '..'].concat(req.url.replace(/\?.*$/, '').split('/'))))
+  } else {
+    serveWebpack(req, res, next)
+  }
+})
+
+app.listen(process.env.PORT || 9090, () =>
+  console.log(`SQE server listening on port ${process.env.PORT || 9090}!`)
+)

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "app",
+  "version": "0.0.0",
+  "main": "./app.js"
+}

--- a/tools/perl-cgi-middleware.js
+++ b/tools/perl-cgi-middleware.js
@@ -1,14 +1,5 @@
 const { resolve } = require('path')
-const webpack = require('webpack')
-const middleware = require('webpack-dev-middleware')
-const conf = require('./webpack.server.js')
-const compiler = webpack(conf)
-const express = require('express')
-const app = express()
-const bodyParser = require('body-parser')
 const url = require('url')
-app.use(bodyParser.json({ type: 'application/json' }))
-
 const { exec } = require('child_process')
 
 /**
@@ -19,7 +10,7 @@ var SERVER_PROTOCOL = 'HTTP/1.1'
 var GATEWAY_INTERFACE = 'CGI/1.1'
 
 const perl = (req, res) => {
-  const file = resolve.apply(null, [__dirname].concat(req.url.split('/')))
+  const file = resolve.apply(null, [__dirname, '..'].concat(req.url.split('/')))
 
   /**
    * Perl-CGI expects all of the CGI params to be set as environment variables.
@@ -104,24 +95,4 @@ const perl = (req, res) => {
   )
 }
 
-app.get('/', (req, res) => {
-  res.sendFile(resolve(__dirname, 'index.html'))
-})
-
-app.use(require('webpack-hot-middleware')(compiler))
-const serveWebpack = middleware(compiler, {
-  publicPath: '/dist/',
-})
-app.get(/.*/, (req, res, next) => {
-  if (/\/vendors/.test(req.url) || /\/resources/.test(req.url) || /\/node_modules/.test(req.url)) {
-    res.sendFile(resolve.apply(null, [__dirname].concat(req.url.replace(/\?.*$/, '').split('/'))))
-  } else {
-    serveWebpack(req, res, next)
-  }
-})
-
-app.post(/\.pl/, perl)
-
-app.listen(process.env.PORT || 9090, () =>
-  console.log(`SQE server listening on port ${process.env.PORT || 9090}!`)
-)
+module.exports = perl

--- a/yarn.lock
+++ b/yarn.lock
@@ -215,6 +215,9 @@ app-root-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
+"app@file:./tools":
+  version "0.0.0"
+
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -1671,6 +1674,12 @@ combine-source-map@~0.8.0:
     lodash.memoize "~3.0.3"
     source-map "~0.5.3"
 
+combined-stream@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -1697,7 +1706,7 @@ component-bind@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
 
-component-emitter@1.2.1, component-emitter@^1.2.1:
+component-emitter@1.2.1, component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
@@ -1781,6 +1790,10 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+cookiejar@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -2904,6 +2917,14 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
+form-data@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.0.0.tgz#6f0aebadcc5da16c13e1ecc11137d85f9b883b25"
@@ -2933,6 +2954,10 @@ formatio@1.2.0, formatio@^1.2.0:
   resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
     samsam "1.x"
+
+formidable@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -4766,7 +4791,7 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
-methods@~1.1.2:
+methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -4827,7 +4852,7 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
-mime@^1.3.4, mime@^1.5.0:
+mime@^1.3.4, mime@^1.4.1, mime@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
@@ -5947,6 +5972,10 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
 process@^0.11.10, process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
@@ -6043,7 +6072,7 @@ qjobs@^1.1.4:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/qjobs/-/qjobs-1.1.5.tgz#659de9f2cf8dcc27a1481276f205377272382e73"
 
-qs@6.5.1, qs@~6.5.1:
+qs@6.5.1, qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
@@ -6191,6 +6220,18 @@ readable-stream@1.1.x, "readable-stream@1.x >=1.1.9":
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-stream@^2.0.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 readable-stream@~2.0.0, readable-stream@~2.0.5:
   version "2.0.6"
@@ -7192,6 +7233,12 @@ string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  dependencies:
+    safe-buffer "~5.1.0"
+
 stringify-object@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.2.tgz#9853052e5a88fb605a44cd27445aa257ad7ffbcd"
@@ -7256,6 +7303,28 @@ subarg@^1.0.0:
   resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
   dependencies:
     minimist "^1.1.0"
+
+superagent@^3.0.0:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.1.1"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.0.5"
+
+supertest@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-3.0.0.tgz#8d4bb68fd1830ee07033b1c5a5a9a4021c965296"
+  dependencies:
+    methods "~1.1.2"
+    superagent "^3.0.0"
 
 supports-color@4.4.0:
   version "4.4.0"


### PR DESCRIPTION
@Bronson-Brown-deVost : related to testing ...

Steps: 
* Pull down this branch
* `yarn`
* `npm run test:server`

If using VSCode, you can drop this config in your .vscode/launch.json:
```json
    {
      "type": "node",
      "request": "launch",
      "name": "test:server",
      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
      "cwd": "${workspaceFolder}",
      "args": [
        "./tests/server/**/*-test.js", "--timeout=120000", "--watch"
      ]
    }
```